### PR TITLE
fix panic when Package returns nil

### DIFF
--- a/zerologlint.go
+++ b/zerologlint.go
@@ -83,8 +83,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 func isInLogPkg(c *ssa.Call) bool {
 	switch v := c.Call.Value.(type) {
 	case ssa.Member:
-		p := v.Package().Pkg.Path()
-		return strings.HasSuffix(p, "github.com/rs/zerolog/log")
+		p := v.Package()
+		if p == nil {
+			return false
+		}
+		return strings.HasSuffix(p.Pkg.Path(), "github.com/rs/zerolog/log")
 	default:
 		return false
 	}


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1010fe448]

goroutine 41605 [running]:
github.com/ykadowak/zerologlint.isInLogPkg(0x101404088?)
        /Users/sergeyvilgelm/Library/Mobile Documents/com~apple~CloudDocs/projects/sv-tools/gochecker/vendor/github.com/ykadowak/zerologlint/zerologlint.go:87 +0x68
github.com/ykadowak/zerologlint.run(0x140af2c1860)
        /Users/sergeyvilgelm/Library/Mobile Documents/com~apple~CloudDocs/projects/sv-tools/gochecker/vendor/github.com/ykadowak/zerologlint/zerologlint.go:41 +0x1d0
golang.org/x/tools/go/analysis/internal/checker.(*action).execOnce(0x1400f649900)
        /Users/sergeyvilgelm/Library/Mobile Documents/com~apple~CloudDocs/projects/sv-tools/gochecker/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go:762 +0x88c
sync.(*Once).doSlow(0x140038da798?, 0x100e6fec8?)
        /Users/sergeyvilgelm/go/go1.20.1/src/sync/once.go:74 +0x100
sync.(*Once).Do(...)
        /Users/sergeyvilgelm/go/go1.20.1/src/sync/once.go:65
golang.org/x/tools/go/analysis/internal/checker.(*action).exec(0x140267aef00?)
        /Users/sergeyvilgelm/Library/Mobile Documents/com~apple~CloudDocs/projects/sv-tools/gochecker/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go:678 +0x40
golang.org/x/tools/go/analysis/internal/checker.execAll.func1(0x0?)
        /Users/sergeyvilgelm/Library/Mobile Documents/com~apple~CloudDocs/projects/sv-tools/gochecker/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go:666 +0x24
created by golang.org/x/tools/go/analysis/internal/checker.execAll
        /Users/sergeyvilgelm/Library/Mobile Documents/com~apple~CloudDocs/projects/sv-tools/gochecker/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go:672 +0x154
```