### PR TITLE
fix: panic on custom marshaller

### DIFF
--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -94,4 +94,27 @@ func ok() {
 			Str("bar", "baz").
 			Int("n", 1),
 		).Send()
+
+	// custom object marshaller
+	f := &Foo{Bar: &Bar{}}
+
+	log.Info().Object("foo", f).Msg("")
+}
+
+type Marshaller interface {
+	MarshalZerologObject(event *zerolog.Event)
+}
+
+type Foo struct {
+	Bar Marshaller
+}
+
+func (f *Foo) MarshalZerologObject(event1 *zerolog.Event) {
+	f.Bar.MarshalZerologObject(event1)
+}
+
+type Bar struct{}
+
+func (b *Bar) MarshalZerologObject(event2 *zerolog.Event) {
+	event2.Str("key", "value")
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -109,12 +109,12 @@ type Foo struct {
 	Bar Marshaller
 }
 
-func (f *Foo) MarshalZerologObject(event1 *zerolog.Event) {
-	f.Bar.MarshalZerologObject(event1)
+func (f *Foo) MarshalZerologObject(event *zerolog.Event) {
+	f.Bar.MarshalZerologObject(event)
 }
 
 type Bar struct{}
 
-func (b *Bar) MarshalZerologObject(event2 *zerolog.Event) {
-	event2.Str("key", "value")
+func (b *Bar) MarshalZerologObject(event *zerolog.Event) {
+	event.Str("key", "value")
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -46,6 +46,11 @@ func bad() {
 					Str("bar", "baz").
 					Int("n", 1),
 		)
+
+	// custom object marshaller
+	f := &Foo{Bar: &Bar{}}
+
+	log.Info().Object("foo", f) // want "must be dispatched by Msg or Send method"
 }
 
 func ok() {

--- a/zerologlint.go
+++ b/zerologlint.go
@@ -117,7 +117,12 @@ func isZerologEvent(v ssa.Value) bool {
 }
 
 func isDispatchMethod(c ssa.CallCommon) bool {
-	m := c.StaticCallee().Name()
+	callee := c.StaticCallee()
+	if callee == nil {
+		return false
+	}
+
+	m := callee.Name()
 	if m == "Send" || m == "Msg" || m == "Msgf" || m == "MsgFunc" {
 		return true
 	}


### PR DESCRIPTION
Hello :wave: 

Due to the use of a custom zerolog marshaller I get a panic from this linter.

Setup:
```
zerologlint: v0.1.2
golangci-lint: v1.53.3
```

Reproducible case:

```go
type Marshaller interface {
	MarshalZerologObject(event *zerolog.Event)
}

type Foo struct {
	Bar Marshaller
}

func (f *Foo) MarshalZerologObject(event1 *zerolog.Event) {
	f.Bar.MarshalZerologObject(event1)
}

type Bar struct{}

func (b *Bar) MarshalZerologObject(event2 *zerolog.Event) {
	event2.Str("key", "value")
}

func main() {
   f := &Foo{Bar: &Bar{}}

   log.Info().Object("foo", f).Msg("")
}
```

When running golangci-lint I get the following error:

```
$> golangci-lint run
ERRO [runner] Panic: zerologlinter: package "job" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory address or nil pointer dereference: goroutine 7512 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:24 +0x65
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1()
	github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:109 +0x285
panic({0xff8920, 0x1ae7b60})
	runtime/panic.go:884 +0x213
golang.org/x/tools/go/ssa.(*Function).Name(...)
	golang.org/x/tools@v0.9.3/go/ssa/ssa.go:1510
github.com/ykadowak/zerologlint.isDispatchMethod(...)
	github.com/ykadowak/zerologlint@v0.1.2/zerologlint.go:120
github.com/ykadowak/zerologlint.inspect({0x1398930, 0xc008ad1900}, 0xc0032f9bf0)
	github.com/ykadowak/zerologlint@v0.1.2/zerologlint.go:86 +0x23e
github.com/ykadowak/zerologlint.run(0xc008f30270)
	github.com/ykadowak/zerologlint@v0.1.2/zerologlint.go:48 +0x2a9
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc003c316b0)
	github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:195 +0xa25
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
	github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:113 +0x1d
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc0015f26e0, {0x11a409f, 0xd}, 0xc004319f48)
	github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x4a
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc00163ea20?)
	github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:112 +0x85
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2(0xc003c316b0)
	github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:80 +0xb4
created by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze
	github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:75 +0x208 
WARN [runner] Can't run linter goanalysis_metalinter: goanalysis_metalinter: zerologlinter: package "job" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory address or nil pointer dereference 
ERRO Running error: 1 error occurred:
	* can't run linter goanalysis_metalinter: goanalysis_metalinter: zerologlinter: package "job" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory address or nil pointer dereference
 
make: *** [Makefile:38: lint] Error 3
``` 

I managed to track the issue in your unit tests. The issue seems to come from the `isDispatchMethod` method when the callee is not a trivially static "call"-mode call to a function.

Here's a PR which fixes the issue.

I would be happy to discuss a better fix or workaround. 

Thanks for your time and your linter :slightly_smiling_face: 