### PR TITLE
change analyzer name and doc

### DIFF
--- a/zerologlint.go
+++ b/zerologlint.go
@@ -13,8 +13,8 @@ import (
 )
 
 var Analyzer = &analysis.Analyzer{
-	Name: "zerologlinter",
-	Doc:  "finds cases where zerolog methods are not followed by Msg or Send",
+	Name: "zerologlint",
+	Doc:  "Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`",
 	Run:  run,
 	Requires: []*analysis.Analyzer{
 		buildssa.Analyzer,


### PR DESCRIPTION
The PR changes the linter's name to `zerologlint`. Also, slightly modifies the linter's doc field.
This is for consistency with [zerologlint in the golangci-lint](https://github.com/golangci/golangci-lint/blob/43849699e5347d6af2f3bd90752f59b1814bff6f/pkg/golinters/zerologlint.go#L12).


After the PR is merged and the new version bumped we can rewrite golangci-lint's code to the:
```go
func NewZerologLint() *goanalysis.Linter {
	a := zerologlint.Analyzer
	return goanalysis.NewLinter(
		a.Name,
		a.Doc,
		[]*analysis.Analyzer{a},
		nil,
	).WithLoadMode(goanalysis.LoadModeTypesInfo)
}
```