### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![build](https://github.com/ykadowak/zerologlint/actions/workflows/testing.yaml/badge.svg)
 
 `zerologlint` is a linter for [zerolog](https://github.com/rs/zerolog) that can be run with `go vet` or through [golangci-lint](https://golangci-lint.run/) since `v1.53.0`.
-It detects the wrong usage of `zerolog` that a user forgets to dispatch `zerolog.Event` with `Send` or `Msg` like functions, in which case nothing will be logged. For more detailed explanations of the cases it detects, see [Examples](#Example).
+It detects the wrong usage of `zerolog` that a user forgets to dispatch `zerolog.Event` with `Send` or `Msg` like functions, in which case nothing will be logged. For more detailed explanations of the cases it detects, see [Examples](#Examples).
 
 ## Install
 


### PR DESCRIPTION
This PR corrects a typo in the link to "Examples".