### PR TITLE
Downgrade the Go version to 1.22

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.21' ]
 
     steps:
       - name: Check out
@@ -21,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go }}
+          go-version: 'stable'
           cache: true
       - name: release
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22', '1.23' ]
+        go: [ 'oldstable', 'stable' ]
 
     steps:
       - name: Check out

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ykadowak/zerologlint
 
-go 1.23
+go 1.22.0
 
 require (
 	github.com/gostaticanalysis/comment v1.4.2


### PR DESCRIPTION
`zerologlint` is used as a library inside [golangci-lint](https://github.com/golangci/golangci-lint/blob/2c8f50828593196c151669a03e3601887be0e99b/go.mod#L124), and it supports Go 1.22 and 1.23. So, if `zerologlint` sets `go 1.23` in `go.mod` this breaks support for 1.22.

Since 1.21, `go` directive is a mandatory requirement: Go toolchains refuse to use modules declaring newer Go versions. See https://go.dev/ref/mod#go-mod-file-go