### PR TITLE
feat: add support for custom zerolog module path prefixes (-prefix flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,3 @@ go build -buildmode=plugin \
   github.com/ykadowak/zerologlint/plugin/zerologlint
 ```
 
-### Programmatic API (golangci-lint custom linter integrations)
-
-Use `NewAnalyzerForSettings` to create an analyzer with settings provided programmatically:
-
-```go
-import "github.com/ykadowak/zerologlint"
-
-analyzer := zerologlint.NewAnalyzerForSettings(zerologlint.Settings{
-    AdditionalPrefixes: []string{"myorg/myzerolog"},
-})
-```

--- a/README.md
+++ b/README.md
@@ -78,13 +78,3 @@ go vet -vettool=`which zerologlint` -zerologlint.prefix=myorg/myzerolog ./...
 go vet -vettool=`which zerologlint` -zerologlint.prefix=myorg/myzerolog,other/zerolog ./...
 ```
 
-### Using golangci-lint (plugin mode)
-
-When building a golangci-lint plugin, pass flags via `ldflags`:
-
-```bash
-go build -buildmode=plugin \
-  -ldflags "-X 'main.flags=-prefix myorg/myzerolog'" \
-  github.com/ykadowak/zerologlint/plugin/zerologlint
-```
-

--- a/README.md
+++ b/README.md
@@ -61,3 +61,41 @@ func dispatcher(e *zerolog.Event) {
     e.Send()
 }
 ```
+
+## Custom Module Paths (zerolog forks/mirrors)
+
+By default, `zerologlint` only inspects code that uses `github.com/rs/zerolog`.
+If your project uses a fork or mirror of zerolog under a different module path, you can configure
+additional module path prefixes.
+
+### Using `go vet` / CLI flag
+
+Pass the `-zerologlint.prefix` flag with a comma-separated list of additional prefixes:
+
+```bash
+go vet -vettool=`which zerologlint` -zerologlint.prefix=myorg/myzerolog ./...
+# multiple prefixes:
+go vet -vettool=`which zerologlint` -zerologlint.prefix=myorg/myzerolog,other/zerolog ./...
+```
+
+### Using golangci-lint (plugin mode)
+
+When building a golangci-lint plugin, pass flags via `ldflags`:
+
+```bash
+go build -buildmode=plugin \
+  -ldflags "-X 'main.flags=-prefix myorg/myzerolog'" \
+  github.com/ykadowak/zerologlint/plugin/zerologlint
+```
+
+### Programmatic API (golangci-lint custom linter integrations)
+
+Use `NewAnalyzerForSettings` to create an analyzer with settings provided programmatically:
+
+```go
+import "github.com/ykadowak/zerologlint"
+
+analyzer := zerologlint.NewAnalyzerForSettings(zerologlint.Settings{
+    AdditionalPrefixes: []string{"myorg/myzerolog"},
+})
+```

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -1,14 +1,21 @@
 // This file can build as a plugin for golangci-lint by below command.
-//
-//	go build -buildmode=plugin -o path_to_plugin_dir github.com/ykadowak/zerologlint/plugin/zerologlint
-//
+//    go build -buildmode=plugin -o path_to_plugin_dir github.com/ykadowak/zerologlint/plugin/zerologlint
 // See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
+
 package main
 
 import (
+	"strings"
+
 	"github.com/ykadowak/zerologlint"
 	"golang.org/x/tools/go/analysis"
 )
+
+// flags for Analyzer.Flag.
+// If you would like to specify flags for your plugin, you can put them via 'ldflags' as below.
+//
+//	$ go build -buildmode=plugin -ldflags "-X 'main.flags=-opt val'" github.com/ykadowak/zerologlint/plugin/zerologlint
+var flags string
 
 // AnalyzerPlugin provides analyzers as a plugin.
 // It follows golangci-lint style plugin.
@@ -17,6 +24,12 @@ var AnalyzerPlugin analyzerPlugin
 type analyzerPlugin struct{}
 
 func (analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
+	if flags != "" {
+		flagset := zerologlint.Analyzer.Flags
+		if err := flagset.Parse(strings.Split(flags, " ")); err != nil {
+			panic("cannot parse flags of zerologlint: " + err.Error())
+		}
+	}
 	return []*analysis.Analyzer{
 		zerologlint.Analyzer,
 	}

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -1,21 +1,14 @@
 // This file can build as a plugin for golangci-lint by below command.
-//    go build -buildmode=plugin -o path_to_plugin_dir github.com/ykadowak/zerologlint/plugin/zerologlint
+//
+//	go build -buildmode=plugin -o path_to_plugin_dir github.com/ykadowak/zerologlint/plugin/zerologlint
+//
 // See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
-
 package main
 
 import (
-	"strings"
-
 	"github.com/ykadowak/zerologlint"
 	"golang.org/x/tools/go/analysis"
 )
-
-// flags for Analyzer.Flag.
-// If you would like to specify flags for your plugin, you can put them via 'ldflags' as below.
-//
-//	$ go build -buildmode=plugin -ldflags "-X 'main.flags=-opt val'" github.com/ykadowak/zerologlint/plugin/zerologlint
-var flags string
 
 // AnalyzerPlugin provides analyzers as a plugin.
 // It follows golangci-lint style plugin.
@@ -24,12 +17,6 @@ var AnalyzerPlugin analyzerPlugin
 type analyzerPlugin struct{}
 
 func (analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
-	if flags != "" {
-		flagset := zerologlint.Analyzer.Flags
-		if err := flagset.Parse(strings.Split(flags, " ")); err != nil {
-			panic("cannot parse flags of zerologlint: " + err.Error())
-		}
-	}
 	return []*analysis.Analyzer{
 		zerologlint.Analyzer,
 	}

--- a/testdata/src/b/b.go
+++ b/testdata/src/b/b.go
@@ -1,0 +1,31 @@
+package b
+
+import (
+	"myfork/myzerolog"
+	"myfork/myzerolog/log"
+)
+
+func positives() {
+	log.Error() // want "must be dispatched by Msg or Send method"
+	log.Info()  // want "must be dispatched by Msg or Send method"
+
+	var err error
+	log.Error().Err(err).Str("foo", "bar") // want "must be dispatched by Msg or Send method"
+
+	logger := myzerolog.New(nil)
+	logger.Info() // want "must be dispatched by Msg or Send method"
+}
+
+func negatives() {
+	log.Fatal().Send()
+	log.Info().Msg("")
+	log.Error().Str("foo", "bar").Send()
+
+	var err error
+	log.Error().Err(err).Str("foo", "bar").Msg("")
+
+	logger := myzerolog.New(nil)
+	logger.Info().Send()
+
+	_ = err
+}

--- a/testdata/src/b/go.mod
+++ b/testdata/src/b/go.mod
@@ -1,0 +1,7 @@
+module b
+
+go 1.19
+
+require myfork v0.0.0
+
+replace myfork => ../myfork

--- a/testdata/src/myfork/go.mod
+++ b/testdata/src/myfork/go.mod
@@ -1,0 +1,3 @@
+module myfork
+
+go 1.19

--- a/testdata/src/myfork/myzerolog/log/log.go
+++ b/testdata/src/myfork/myzerolog/log/log.go
@@ -1,0 +1,10 @@
+// Package log provides global logging functions using the myzerolog fork.
+package log
+
+import "myfork/myzerolog"
+
+func Info() *myzerolog.Event  { return &myzerolog.Event{} }
+func Error() *myzerolog.Event { return &myzerolog.Event{} }
+func Debug() *myzerolog.Event { return &myzerolog.Event{} }
+func Warn() *myzerolog.Event  { return &myzerolog.Event{} }
+func Fatal() *myzerolog.Event { return &myzerolog.Event{} }

--- a/testdata/src/myfork/myzerolog/zerolog.go
+++ b/testdata/src/myfork/myzerolog/zerolog.go
@@ -1,0 +1,23 @@
+// Package myzerolog is a minimal zerolog fork stub for testing purposes.
+package myzerolog
+
+import "io"
+
+// Event represents a log event (mirrors zerolog.Event).
+type Event struct{}
+
+func (e *Event) Str(key, val string) *Event  { return e }
+func (e *Event) Int(key string, val int) *Event { return e }
+func (e *Event) Err(err error) *Event        { return e }
+func (e *Event) Send()                       {}
+func (e *Event) Msg(msg string)              {}
+func (e *Event) Msgf(format string, v ...interface{}) {}
+
+// Logger mirrors zerolog.Logger.
+type Logger struct{}
+
+func New(w io.Writer) Logger { return Logger{} }
+func (l Logger) Info() *Event  { return &Event{} }
+func (l Logger) Error() *Event { return &Event{} }
+func (l Logger) Debug() *Event { return &Event{} }
+func (l Logger) Warn() *Event  { return &Event{} }

--- a/zerologlint.go
+++ b/zerologlint.go
@@ -1,6 +1,7 @@
 package zerologlint
 
 import (
+	"flag"
 	"go/token"
 	"go/types"
 	"strings"
@@ -12,6 +13,16 @@ import (
 	"github.com/gostaticanalysis/comment/passes/commentmap"
 )
 
+const defaultZerologPath = "github.com/rs/zerolog"
+
+// Settings holds the configurable options for the zerologlint analyzer.
+type Settings struct {
+	// AdditionalPrefixes is the list of module path prefixes that are treated as zerolog.
+	// The default prefix github.com/rs/zerolog is always included.
+	// AdditionalPrefixes allows specifying mirrors or forks of zerolog.
+	AdditionalPrefixes []string
+}
+
 var Analyzer = &analysis.Analyzer{
 	Name: "zerologlint",
 	Doc:  "Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`",
@@ -20,6 +31,27 @@ var Analyzer = &analysis.Analyzer{
 		buildssa.Analyzer,
 		commentmap.Analyzer,
 	},
+}
+
+func init() {
+	Analyzer.Flags.Init("zerologlint", flag.ContinueOnError)
+	Analyzer.Flags.String("prefix", "", "comma-separated list of additional module path prefixes to treat as zerolog (e.g., myorg/myzerolog)")
+}
+
+// NewAnalyzerForSettings returns a new Analyzer pre-configured with the given Settings.
+// This is primarily used by golangci integrations that pass configuration programmatically.
+func NewAnalyzerForSettings(settings Settings) *analysis.Analyzer {
+	a := &analysis.Analyzer{
+		Name: "zerologlint",
+		Doc:  "Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`",
+		Run:  newRunner(settings),
+		Requires: []*analysis.Analyzer{
+			buildssa.Analyzer,
+			commentmap.Analyzer,
+		},
+	}
+	a.Flags.Init("zerologlint", flag.ContinueOnError)
+	return a
 }
 
 type posser interface {
@@ -46,52 +78,87 @@ type linter struct {
 	//       deleteLater takes care of the log.Info() block.
 	deleteLater map[posser]struct{}
 	recLimit    uint
+	// prefixes is the combined list of module path prefixes to match against.
+	// It always contains defaultZerologPath and any additional prefixes from Settings or flags.
+	prefixes []string
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
-	srcFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
+// resolvePrefixes builds the final list of prefixes from the analyzer flags and the provided additional list.
+func resolvePrefixes(pass *analysis.Pass, extra []string) []string {
+	prefixes := []string{defaultZerologPath}
 
-	l := &linter{
-		eventSet:    make(map[posser]struct{}),
-		deleteLater: make(map[posser]struct{}),
-		recLimit:    100,
+	// Merge additional prefixes from Settings (programmatic API).
+	for _, p := range extra {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			prefixes = append(prefixes, p)
+		}
 	}
 
-	for _, sf := range srcFuncs {
-		for _, b := range sf.Blocks {
-			for _, instr := range b.Instrs {
-				if c, ok := instr.(*ssa.Call); ok {
-					l.inspect(c)
-				} else if c, ok := instr.(*ssa.Defer); ok {
-					l.inspect(c)
-				}
+	// Merge additional prefixes from -prefix flag (CLI / golangci-lint flags).
+	if ff := pass.Analyzer.Flags.Lookup("prefix"); ff != nil {
+		for _, p := range strings.Split(ff.Value.String(), ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				prefixes = append(prefixes, p)
 			}
 		}
 	}
 
-	// apply deleteLater to envetSet for else branches of if-else cases
+	return prefixes
+}
 
-	for k := range l.deleteLater {
-		delete(l.eventSet, k)
+func run(pass *analysis.Pass) (interface{}, error) {
+	return newRunner(Settings{})(pass)
+}
+
+func newRunner(settings Settings) func(pass *analysis.Pass) (interface{}, error) {
+	return func(pass *analysis.Pass) (interface{}, error) {
+		srcFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
+
+		l := &linter{
+			eventSet:    make(map[posser]struct{}),
+			deleteLater: make(map[posser]struct{}),
+			recLimit:    100,
+			prefixes:    resolvePrefixes(pass, settings.AdditionalPrefixes),
+		}
+
+		for _, sf := range srcFuncs {
+			for _, b := range sf.Blocks {
+				for _, instr := range b.Instrs {
+					if c, ok := instr.(*ssa.Call); ok {
+						l.inspect(c)
+					} else if c, ok := instr.(*ssa.Defer); ok {
+						l.inspect(c)
+					}
+				}
+			}
+		}
+
+		// apply deleteLater to envetSet for else branches of if-else cases
+
+		for k := range l.deleteLater {
+			delete(l.eventSet, k)
+		}
+
+		// At the end, if the set is clear -> ok.
+		// Otherwise, there must be a left zerolog.Event var that weren't dispatched. So report it.
+		for k := range l.eventSet {
+			pass.Reportf(k.Pos(), "must be dispatched by Msg or Send method")
+		}
+
+		return nil, nil
 	}
-
-	// At the end, if the set is clear -> ok.
-	// Otherwise, there must be a left zerolog.Event var that weren't dispatched. So report it.
-	for k := range l.eventSet {
-		pass.Reportf(k.Pos(), "must be dispatched by Msg or Send method")
-	}
-
-	return nil, nil
 }
 
 func (l *linter) inspect(cd callDefer) {
 	c := cd.Common()
 
-	// check if it's in github.com/rs/zerolog/log since there's some
-	// functions in github.com/rs/zerolog that returns zerolog.Event
+	// check if it's in the log package of any of the configured zerolog prefixes
+	// since there's some functions in the packages that return zerolog.Event
 	// which should not be included. However, zerolog.Logger receiver is an exception.
-	if isInLogPkg(*c) || isLoggerRecv(*c) {
-		if isZerologEvent(c.Value) {
+	if l.isInLogPkg(*c) || l.isLoggerRecv(*c) {
+		if l.isZerologEvent(c.Value) {
 			// this ssa block should be dispatched afterwards at some point
 			l.eventSet[cd] = struct{}{}
 			return
@@ -109,10 +176,10 @@ func (l *linter) inspect(cd callDefer) {
 	if !isDispatchMethod(f) {
 		shouldReturn := true
 		for _, p := range f.Params {
-			if isZerologEvent(p) {
+			if l.isZerologEvent(p) {
 				// check if this zerolog.Event as a parameter is dispatched in the function
 				// TODO: technically, it can be dispatched in another function that is called in this function, and
-				//       this algorithm cannot track that. But I'm tired of thinking about that for now.
+				//       this algorithm cannot trace that. But I'm tired of thinking about that for now.
 				for _, b := range f.Blocks {
 					for _, instr := range b.Instrs {
 						switch v := instr.(type) {
@@ -136,7 +203,7 @@ func (l *linter) inspect(cd callDefer) {
 		}
 	}
 	for _, arg := range c.Args {
-		if isZerologEvent(arg) {
+		if l.isZerologEvent(arg) {
 			// if there's branch, track both ways
 			// this is for the case like:
 			//   logger := log.Info()
@@ -190,7 +257,7 @@ func (l *linter) dfsEdge(v ssa.Value, visit map[ssa.Value]struct{}, cnt uint) {
 func inspectDispatchInFunction(cc *ssa.CallCommon) bool {
 	if isDispatchMethod(cc.StaticCallee()) {
 		for _, arg := range cc.Args {
-			if isZerologEvent(arg) {
+			if isZerologEventAny(arg) {
 				return true
 			}
 		}
@@ -198,31 +265,52 @@ func inspectDispatchInFunction(cc *ssa.CallCommon) bool {
 	return false
 }
 
-func isInLogPkg(c ssa.CallCommon) bool {
+func (l *linter) isInLogPkg(c ssa.CallCommon) bool {
 	switch v := c.Value.(type) {
 	case ssa.Member:
 		p := v.Package()
 		if p == nil {
 			return false
 		}
-		return strings.HasSuffix(p.Pkg.Path(), "github.com/rs/zerolog/log")
-	}
-	return false
-}
-
-func isLoggerRecv(c ssa.CallCommon) bool {
-	switch f := c.Value.(type) {
-	case *ssa.Function:
-		if recv := f.Signature.Recv(); recv != nil {
-			return strings.HasSuffix(types.TypeString(recv.Type(), nil), "zerolog.Logger")
+		pkgPath := p.Pkg.Path()
+		for _, prefix := range l.prefixes {
+			if strings.HasSuffix(pkgPath, prefix+"/log") {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func isZerologEvent(v ssa.Value) bool {
+func (l *linter) isLoggerRecv(c ssa.CallCommon) bool {
+	switch f := c.Value.(type) {
+	case *ssa.Function:
+		if recv := f.Signature.Recv(); recv != nil {
+			ts := types.TypeString(recv.Type(), nil)
+			for _, prefix := range l.prefixes {
+				if strings.HasSuffix(ts, prefix+".Logger") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (l *linter) isZerologEvent(v ssa.Value) bool {
 	ts := v.Type().String()
-	return strings.HasSuffix(ts, "github.com/rs/zerolog.Event")
+	for _, prefix := range l.prefixes {
+		if strings.HasSuffix(ts, prefix+".Event") {
+			return true
+		}
+	}
+	return false
+}
+
+// isZerologEventAny checks if a value is a zerolog Event from any path (used in dispatch checks).
+func isZerologEventAny(v ssa.Value) bool {
+	ts := v.Type().String()
+	return strings.Contains(ts, ".Event")
 }
 
 func isDispatchMethod(f *ssa.Function) bool {
@@ -249,7 +337,7 @@ func getRootSsaValue(v ssa.Value) ssa.Value {
 		// Even when there is a receiver, if it's a zerolog.Logger instance, return this block
 		// eg. Info() method in zerolog.New(os.Stdout).Info()
 		root := v.Call.Args[0]
-		if !isZerologEvent(root) {
+		if !isZerologEventAny(root) {
 			return v
 		}
 

--- a/zerologlint.go
+++ b/zerologlint.go
@@ -13,18 +13,10 @@ import (
 	"github.com/gostaticanalysis/comment/passes/commentmap"
 )
 
-// Settings holds the configurable options for the zerologlint analyzer.
-type Settings struct {
-	// AdditionalPrefixes is the list of module path prefixes that are treated as zerolog
-	// in addition to the default "github.com/rs/zerolog".
-	// Use this to support zerolog forks or mirrors.
-	AdditionalPrefixes []string
-}
-
 var Analyzer = &analysis.Analyzer{
 	Name: "zerologlint",
 	Doc:  "Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`",
-	Run:  func(pass *analysis.Pass) (interface{}, error) { return run(pass) },
+	Run:  run,
 	Requires: []*analysis.Analyzer{
 		buildssa.Analyzer,
 		commentmap.Analyzer,
@@ -34,21 +26,6 @@ var Analyzer = &analysis.Analyzer{
 func init() {
 	Analyzer.Flags.Init("zerologlint", flag.ContinueOnError)
 	Analyzer.Flags.String("prefix", "", "comma-separated list of additional module path prefixes to treat as zerolog (e.g., myorg/myzerolog)")
-}
-
-// NewAnalyzerForSettings returns a new Analyzer pre-configured with the given Settings.
-// This is primarily used by golangci integrations that pass configuration programmatically.
-func NewAnalyzerForSettings(settings Settings) *analysis.Analyzer {
-	a := &analysis.Analyzer{
-		Name: "zerologlint",
-		Doc:  Analyzer.Doc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
-			return run(pass, settings.AdditionalPrefixes...)
-		},
-		Requires: Analyzer.Requires,
-	}
-	a.Flags.Init("zerologlint", flag.ContinueOnError)
-	return a
 }
 
 type posser interface {
@@ -78,12 +55,10 @@ type linter struct {
 	prefixes    []string
 }
 
-func run(pass *analysis.Pass, additionalPrefixes ...string) (interface{}, error) {
+func run(pass *analysis.Pass) (interface{}, error) {
 	srcFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
 
 	prefixes := []string{"github.com/rs/zerolog"}
-	prefixes = append(prefixes, additionalPrefixes...)
-	// also pick up prefixes from the -prefix flag (CLI / golangci-lint plugin flags)
 	if ff := pass.Analyzer.Flags.Lookup("prefix"); ff != nil {
 		for _, p := range strings.Split(ff.Value.String(), ",") {
 			if p = strings.TrimSpace(p); p != "" {

--- a/zerologlint.go
+++ b/zerologlint.go
@@ -13,20 +13,18 @@ import (
 	"github.com/gostaticanalysis/comment/passes/commentmap"
 )
 
-const defaultZerologPath = "github.com/rs/zerolog"
-
 // Settings holds the configurable options for the zerologlint analyzer.
 type Settings struct {
-	// AdditionalPrefixes is the list of module path prefixes that are treated as zerolog.
-	// The default prefix github.com/rs/zerolog is always included.
-	// AdditionalPrefixes allows specifying mirrors or forks of zerolog.
+	// AdditionalPrefixes is the list of module path prefixes that are treated as zerolog
+	// in addition to the default "github.com/rs/zerolog".
+	// Use this to support zerolog forks or mirrors.
 	AdditionalPrefixes []string
 }
 
 var Analyzer = &analysis.Analyzer{
 	Name: "zerologlint",
 	Doc:  "Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`",
-	Run:  run,
+	Run:  func(pass *analysis.Pass) (interface{}, error) { return run(pass) },
 	Requires: []*analysis.Analyzer{
 		buildssa.Analyzer,
 		commentmap.Analyzer,
@@ -43,12 +41,11 @@ func init() {
 func NewAnalyzerForSettings(settings Settings) *analysis.Analyzer {
 	a := &analysis.Analyzer{
 		Name: "zerologlint",
-		Doc:  "Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`",
-		Run:  newRunner(settings),
-		Requires: []*analysis.Analyzer{
-			buildssa.Analyzer,
-			commentmap.Analyzer,
+		Doc:  Analyzer.Doc,
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			return run(pass, settings.AdditionalPrefixes...)
 		},
+		Requires: Analyzer.Requires,
 	}
 	a.Flags.Init("zerologlint", flag.ContinueOnError)
 	return a
@@ -78,84 +75,62 @@ type linter struct {
 	//       deleteLater takes care of the log.Info() block.
 	deleteLater map[posser]struct{}
 	recLimit    uint
-	// prefixes is the combined list of module path prefixes to match against.
-	// It always contains defaultZerologPath and any additional prefixes from Settings or flags.
-	prefixes []string
+	prefixes    []string
 }
 
-// resolvePrefixes builds the final list of prefixes from the analyzer flags and the provided additional list.
-func resolvePrefixes(pass *analysis.Pass, extra []string) []string {
-	prefixes := []string{defaultZerologPath}
+func run(pass *analysis.Pass, additionalPrefixes ...string) (interface{}, error) {
+	srcFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
 
-	// Merge additional prefixes from Settings (programmatic API).
-	for _, p := range extra {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			prefixes = append(prefixes, p)
-		}
-	}
-
-	// Merge additional prefixes from -prefix flag (CLI / golangci-lint flags).
+	prefixes := []string{"github.com/rs/zerolog"}
+	prefixes = append(prefixes, additionalPrefixes...)
+	// also pick up prefixes from the -prefix flag (CLI / golangci-lint plugin flags)
 	if ff := pass.Analyzer.Flags.Lookup("prefix"); ff != nil {
 		for _, p := range strings.Split(ff.Value.String(), ",") {
-			p = strings.TrimSpace(p)
-			if p != "" {
+			if p = strings.TrimSpace(p); p != "" {
 				prefixes = append(prefixes, p)
 			}
 		}
 	}
 
-	return prefixes
-}
+	l := &linter{
+		eventSet:    make(map[posser]struct{}),
+		deleteLater: make(map[posser]struct{}),
+		recLimit:    100,
+		prefixes:    prefixes,
+	}
 
-func run(pass *analysis.Pass) (interface{}, error) {
-	return newRunner(Settings{})(pass)
-}
-
-func newRunner(settings Settings) func(pass *analysis.Pass) (interface{}, error) {
-	return func(pass *analysis.Pass) (interface{}, error) {
-		srcFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
-
-		l := &linter{
-			eventSet:    make(map[posser]struct{}),
-			deleteLater: make(map[posser]struct{}),
-			recLimit:    100,
-			prefixes:    resolvePrefixes(pass, settings.AdditionalPrefixes),
-		}
-
-		for _, sf := range srcFuncs {
-			for _, b := range sf.Blocks {
-				for _, instr := range b.Instrs {
-					if c, ok := instr.(*ssa.Call); ok {
-						l.inspect(c)
-					} else if c, ok := instr.(*ssa.Defer); ok {
-						l.inspect(c)
-					}
+	for _, sf := range srcFuncs {
+		for _, b := range sf.Blocks {
+			for _, instr := range b.Instrs {
+				if c, ok := instr.(*ssa.Call); ok {
+					l.inspect(c)
+				} else if c, ok := instr.(*ssa.Defer); ok {
+					l.inspect(c)
 				}
 			}
 		}
-
-		// apply deleteLater to envetSet for else branches of if-else cases
-
-		for k := range l.deleteLater {
-			delete(l.eventSet, k)
-		}
-
-		// At the end, if the set is clear -> ok.
-		// Otherwise, there must be a left zerolog.Event var that weren't dispatched. So report it.
-		for k := range l.eventSet {
-			pass.Reportf(k.Pos(), "must be dispatched by Msg or Send method")
-		}
-
-		return nil, nil
 	}
+
+	// apply deleteLater to envetSet for else branches of if-else cases
+
+	for k := range l.deleteLater {
+		delete(l.eventSet, k)
+	}
+
+	// At the end, if the set is clear -> ok.
+	// Otherwise, there must be a left zerolog.Event var that weren't dispatched. So report it.
+	for k := range l.eventSet {
+		pass.Reportf(k.Pos(), "must be dispatched by Msg or Send method")
+	}
+
+	return nil, nil
 }
 
 func (l *linter) inspect(cd callDefer) {
 	c := cd.Common()
 
-	// check if it's in the log package of any of the configured zerolog prefixes
-	// since there's some functions in the packages that return zerolog.Event
+	// check if it's in github.com/rs/zerolog/log since there's some
+	// functions in github.com/rs/zerolog that returns zerolog.Event
 	// which should not be included. However, zerolog.Logger receiver is an exception.
 	if l.isInLogPkg(*c) || l.isLoggerRecv(*c) {
 		if l.isZerologEvent(c.Value) {
@@ -179,17 +154,17 @@ func (l *linter) inspect(cd callDefer) {
 			if l.isZerologEvent(p) {
 				// check if this zerolog.Event as a parameter is dispatched in the function
 				// TODO: technically, it can be dispatched in another function that is called in this function, and
-				//       this algorithm cannot trace that. But I'm tired of thinking about that for now.
+				//       this algorithm cannot track that. But I'm tired of thinking about that for now.
 				for _, b := range f.Blocks {
 					for _, instr := range b.Instrs {
 						switch v := instr.(type) {
 						case *ssa.Call:
-							if inspectDispatchInFunction(v.Common(), l.prefixes) {
+							if l.inspectDispatchInFunction(v.Common()) {
 								shouldReturn = false
 								break
 							}
 						case *ssa.Defer:
-							if inspectDispatchInFunction(v.Common(), l.prefixes) {
+							if l.inspectDispatchInFunction(v.Common()) {
 								shouldReturn = false
 								break
 							}
@@ -224,7 +199,7 @@ func (l *linter) inspect(cd callDefer) {
 					l.dfsEdge(edge, make(map[ssa.Value]struct{}), 0)
 				}
 			} else {
-				val := getRootSsaValue(arg, l.prefixes)
+				val := l.getRootSsaValue(arg)
 				delete(l.eventSet, val)
 			}
 		}
@@ -243,7 +218,7 @@ func (l *linter) dfsEdge(v ssa.Value, visit map[ssa.Value]struct{}, cnt uint) {
 	}
 	visit[v] = struct{}{}
 
-	val := getRootSsaValue(v, l.prefixes)
+	val := l.getRootSsaValue(v)
 	phi, ok := val.(*ssa.Phi)
 	if !ok {
 		l.deleteLater[val] = struct{}{}
@@ -254,10 +229,10 @@ func (l *linter) dfsEdge(v ssa.Value, visit map[ssa.Value]struct{}, cnt uint) {
 	}
 }
 
-func inspectDispatchInFunction(cc *ssa.CallCommon, prefixes []string) bool {
+func (l *linter) inspectDispatchInFunction(cc *ssa.CallCommon) bool {
 	if isDispatchMethod(cc.StaticCallee()) {
 		for _, arg := range cc.Args {
-			if isZerologEventForPrefixes(arg, prefixes) {
+			if l.isZerologEvent(arg) {
 				return true
 			}
 		}
@@ -272,9 +247,8 @@ func (l *linter) isInLogPkg(c ssa.CallCommon) bool {
 		if p == nil {
 			return false
 		}
-		pkgPath := p.Pkg.Path()
 		for _, prefix := range l.prefixes {
-			if strings.HasSuffix(pkgPath, prefix+"/log") {
+			if strings.HasSuffix(p.Pkg.Path(), prefix+"/log") {
 				return true
 			}
 		}
@@ -307,17 +281,6 @@ func (l *linter) isZerologEvent(v ssa.Value) bool {
 	return false
 }
 
-// isZerologEventForPrefixes checks whether v's type is a zerolog Event for any of the given prefixes.
-func isZerologEventForPrefixes(v ssa.Value, prefixes []string) bool {
-	ts := v.Type().String()
-	for _, prefix := range prefixes {
-		if strings.HasSuffix(ts, prefix+".Event") {
-			return true
-		}
-	}
-	return false
-}
-
 func isDispatchMethod(f *ssa.Function) bool {
 	if f == nil {
 		return false
@@ -329,7 +292,7 @@ func isDispatchMethod(f *ssa.Function) bool {
 	return false
 }
 
-func getRootSsaValue(v ssa.Value, prefixes []string) ssa.Value {
+func (l *linter) getRootSsaValue(v ssa.Value) ssa.Value {
 	if c, ok := v.(*ssa.Call); ok {
 		v := c.Value()
 
@@ -342,13 +305,13 @@ func getRootSsaValue(v ssa.Value, prefixes []string) ssa.Value {
 		// Even when there is a receiver, if it's a zerolog.Logger instance, return this block
 		// eg. Info() method in zerolog.New(os.Stdout).Info()
 		root := v.Call.Args[0]
-		if !isZerologEventForPrefixes(root, prefixes) {
+		if !l.isZerologEvent(root) {
 			return v
 		}
 
 		// Ok to just return the receiver because all the method in this
 		// chain is zerolog.Event at this point.
-		return getRootSsaValue(root, prefixes)
+		return l.getRootSsaValue(root)
 	}
 	return v
 }

--- a/zerologlint.go
+++ b/zerologlint.go
@@ -184,12 +184,12 @@ func (l *linter) inspect(cd callDefer) {
 					for _, instr := range b.Instrs {
 						switch v := instr.(type) {
 						case *ssa.Call:
-							if inspectDispatchInFunction(v.Common()) {
+							if inspectDispatchInFunction(v.Common(), l.prefixes) {
 								shouldReturn = false
 								break
 							}
 						case *ssa.Defer:
-							if inspectDispatchInFunction(v.Common()) {
+							if inspectDispatchInFunction(v.Common(), l.prefixes) {
 								shouldReturn = false
 								break
 							}
@@ -224,7 +224,7 @@ func (l *linter) inspect(cd callDefer) {
 					l.dfsEdge(edge, make(map[ssa.Value]struct{}), 0)
 				}
 			} else {
-				val := getRootSsaValue(arg)
+				val := getRootSsaValue(arg, l.prefixes)
 				delete(l.eventSet, val)
 			}
 		}
@@ -243,7 +243,7 @@ func (l *linter) dfsEdge(v ssa.Value, visit map[ssa.Value]struct{}, cnt uint) {
 	}
 	visit[v] = struct{}{}
 
-	val := getRootSsaValue(v)
+	val := getRootSsaValue(v, l.prefixes)
 	phi, ok := val.(*ssa.Phi)
 	if !ok {
 		l.deleteLater[val] = struct{}{}
@@ -254,10 +254,10 @@ func (l *linter) dfsEdge(v ssa.Value, visit map[ssa.Value]struct{}, cnt uint) {
 	}
 }
 
-func inspectDispatchInFunction(cc *ssa.CallCommon) bool {
+func inspectDispatchInFunction(cc *ssa.CallCommon, prefixes []string) bool {
 	if isDispatchMethod(cc.StaticCallee()) {
 		for _, arg := range cc.Args {
-			if isZerologEventAny(arg) {
+			if isZerologEventForPrefixes(arg, prefixes) {
 				return true
 			}
 		}
@@ -307,10 +307,15 @@ func (l *linter) isZerologEvent(v ssa.Value) bool {
 	return false
 }
 
-// isZerologEventAny checks if a value is a zerolog Event from any path (used in dispatch checks).
-func isZerologEventAny(v ssa.Value) bool {
+// isZerologEventForPrefixes checks whether v's type is a zerolog Event for any of the given prefixes.
+func isZerologEventForPrefixes(v ssa.Value, prefixes []string) bool {
 	ts := v.Type().String()
-	return strings.Contains(ts, ".Event")
+	for _, prefix := range prefixes {
+		if strings.HasSuffix(ts, prefix+".Event") {
+			return true
+		}
+	}
+	return false
 }
 
 func isDispatchMethod(f *ssa.Function) bool {
@@ -324,7 +329,7 @@ func isDispatchMethod(f *ssa.Function) bool {
 	return false
 }
 
-func getRootSsaValue(v ssa.Value) ssa.Value {
+func getRootSsaValue(v ssa.Value, prefixes []string) ssa.Value {
 	if c, ok := v.(*ssa.Call); ok {
 		v := c.Value()
 
@@ -337,13 +342,13 @@ func getRootSsaValue(v ssa.Value) ssa.Value {
 		// Even when there is a receiver, if it's a zerolog.Logger instance, return this block
 		// eg. Info() method in zerolog.New(os.Stdout).Info()
 		root := v.Call.Args[0]
-		if !isZerologEventAny(root) {
+		if !isZerologEventForPrefixes(root, prefixes) {
 			return v
 		}
 
 		// Ok to just return the receiver because all the method in this
 		// chain is zerolog.Event at this point.
-		return getRootSsaValue(root)
+		return getRootSsaValue(root, prefixes)
 	}
 	return v
 }

--- a/zerologlint_test.go
+++ b/zerologlint_test.go
@@ -14,12 +14,12 @@ func TestAnalyzer(t *testing.T) {
 	analysistest.Run(t, testdata, zerologlint.Analyzer, "a")
 }
 
-// TestAnalyzerWithAdditionalPrefix tests that the analyzer correctly handles
-// a custom zerolog fork specified via AdditionalPrefixes in Settings.
+// TestAnalyzerWithAdditionalPrefix tests that the -prefix flag correctly extends
+// the analyzer to handle a zerolog fork under a custom module path.
 func TestAnalyzerWithAdditionalPrefix(t *testing.T) {
-	a := zerologlint.NewAnalyzerForSettings(zerologlint.Settings{
-		AdditionalPrefixes: []string{"myfork/myzerolog"},
-	})
+	a := *zerologlint.Analyzer
+	a.Flags.Init("zerologlint", 0)
+	a.Flags.Set("prefix", "myfork/myzerolog")
 	testdata := testutil.WithModules(t, analysistest.TestData(), nil)
-	analysistest.Run(t, testdata, a, "b")
+	analysistest.Run(t, testdata, &a, "b")
 }

--- a/zerologlint_test.go
+++ b/zerologlint_test.go
@@ -13,3 +13,13 @@ func TestAnalyzer(t *testing.T) {
 	testdata := testutil.WithModules(t, analysistest.TestData(), nil)
 	analysistest.Run(t, testdata, zerologlint.Analyzer, "a")
 }
+
+// TestAnalyzerWithAdditionalPrefix tests that the analyzer correctly handles
+// a custom zerolog fork specified via AdditionalPrefixes in Settings.
+func TestAnalyzerWithAdditionalPrefix(t *testing.T) {
+	a := zerologlint.NewAnalyzerForSettings(zerologlint.Settings{
+		AdditionalPrefixes: []string{"myfork/myzerolog"},
+	})
+	testdata := testutil.WithModules(t, analysistest.TestData(), nil)
+	analysistest.Run(t, testdata, a, "b")
+}


### PR DESCRIPTION
## Why

`zerologlint` only recognises `github.com/rs/zerolog` as the zerolog module. Projects that use a fork or internal mirror of zerolog under a different module path get no coverage: the linter silently ignores undispatched events from those packages.

## What changed

### `zerologlint.go`

A `-prefix` flag is registered on `Analyzer.Flags` in `init()`. It accepts a comma-separated list of additional module path prefixes that should be treated as zerolog, on top of the always-present default `github.com/rs/zerolog`.

At the start of `run()`, the flag value is read and the final prefix list is built. That list is stored on the `linter` struct as `prefixes []string`.

The five functions that previously hardcoded `"github.com/rs/zerolog"` — `isInLogPkg`, `isLoggerRecv`, `isZerologEvent`, `inspectDispatchInFunction`, and `getRootSsaValue` — are promoted from package-level functions to methods on `linter`. Their bodies are otherwise unchanged; the hardcoded string is replaced by a loop over `l.prefixes`.

### `zerologlint_test.go`

`TestAnalyzerWithAdditionalPrefix` sets the `-prefix` flag to `myfork/myzerolog` on a copy of `Analyzer` and runs it against testdata package `b`, which uses the fork stub.

### `testdata/src/b/` and `testdata/src/myfork/`

A minimal zerolog fork stub (`myfork/myzerolog`) and a test package (`b`) that imports it, used only by the new test.

### `README.md`

Documents the `-prefix` flag with a `go vet` usage example.

## Usage

```bash
# single prefix
go vet -vettool=`which zerologlint` -zerologlint.prefix=myorg/myzerolog ./...

# multiple prefixes (comma-separated)
go vet -vettool=`which zerologlint` -zerologlint.prefix=myorg/myzerolog,other/zerolog ./...
```

## golangci-lint

This was also tested end-to-end with a custom build of golangci-lint that pointed at this branch. The flag mechanism works correctly: without `prefix` configured the linter produces no false positives on fork code; with `prefix` set it correctly flags undispatched events.

golangci-lint passes analyzer settings by calling `f.Value.Set(value)` on the registered flag for each key found under `linters-settings.<lintername>` in the YAML config. Because the `-prefix` flag is now registered on `Analyzer.Flags`, the plumbing already works on the zerologlint side. The two changes required in the golangci-lint repository to expose it through YAML are:

**`pkg/config/linters_settings.go`** — add a settings struct and a field on `LintersSettings`:

```go
type ZerologLintSettings struct {
    Prefix string `mapstructure:"prefix"`
}

// inside LintersSettings:
Zerologlint ZerologLintSettings
```

**`pkg/golinters/zerologlint/zerologlint.go`** — pass the settings as the cfg map:

```go
func New(settings *config.ZerologLintSettings) *goanalysis.Linter {
    a := zerologlint.Analyzer

    var cfg map[string]map[string]any
    if settings != nil && settings.Prefix != "" {
        cfg = map[string]map[string]any{
            a.Name: {"prefix": settings.Prefix},
        }
    }

    return goanalysis.NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, cfg).
        WithLoadMode(goanalysis.LoadModeTypesInfo)
}
```

With those two changes in place, the following `.golangci.yml` configuration works as expected:

```yaml
linters-settings:
  zerologlint:
    prefix: myorg/myzerolog        # comma-separated for multiple: a/zerolog,b/zerolog
```

---

_The code, description, and title of this PR were created by [Claude](https://claude.ai) and reviewed by a human._